### PR TITLE
[refactor]: use the new generalizable procedures in `trpc` for query authorization

### DIFF
--- a/src/components/ExerciseSummary/containers/AddNewExerciseModal.tsx
+++ b/src/components/ExerciseSummary/containers/AddNewExerciseModal.tsx
@@ -45,7 +45,7 @@ const AddNewExerciseModal = ({
   const [selectedExerciseMap, setExerciseSelected] = React.useState(new Map<string, boolean>());
   const [selectedTab, setSelectedTab] = React.useState<"all" | "recent">("all");
 
-  const recent_exercises = trpcNextHooks.exercise.me_recent_unique
+  const recent_exercises = trpcNextHooks.exercise.my_unique_recent
     .useQuery({}, { enabled: selectedTab == "recent" });
 
   const selectedFilters = useSearchFilters();

--- a/src/layouts/mainLayout.tsx
+++ b/src/layouts/mainLayout.tsx
@@ -52,7 +52,7 @@ export const MainLayout = ({ session, children, appLocation }: LayoutProps) => {
     }
 
     trpcNextHooks.exercise.public_directory.useQuery(undefined, {
-        // context: { skipBatch: true },
+        trpc: { context: { skipBatch: true } },
         staleTime: Infinity,
         refetchOnWindowFocus: false,
         refetchOnMount: false,

--- a/src/pages/[user]/exercise/[exercise_id].tsx
+++ b/src/pages/[user]/exercise/[exercise_id].tsx
@@ -17,7 +17,7 @@ type HeadersEnum = "weight" | "reps" | "rpe" | "date"
 const UserExercisePage: NextPage = () => {
     const router = useRouter();
     const exercise_id = router.query.exercise_id as string;
-    const { data: userExercise, isLoading: exercise_isLoading } = trpcNextHooks.user.me_get_exercise_data_by_id
+    const { data: userExercise, isLoading: exercise_isLoading } = trpcNextHooks.user.my_specific_exercise_data
         .useQuery({ exercise_id }, { enabled: !!exercise_id, staleTime: 1000 * 60 * 30, });
     console.log(router, exercise_id)
     return (

--- a/src/server/routers/next-auth.ts
+++ b/src/server/routers/next-auth.ts
@@ -1,8 +1,8 @@
-import { publicProcedure, router } from "@server/trpc";
+import { appUserProcedure, publicProcedure, router } from "@server/trpc";
 import { TRPCError } from "@trpc/server";
 
 export const authRouter = router({
-  get_session: publicProcedure.query(async ({ ctx }) => {
+  get_session: appUserProcedure.query(async ({ ctx }) => {
     console.log(`[trpc Procedure]["get_session"] Incoming request headers: `, ctx.req?.headers);
     console.log(`[trpc Procedure]["get_session"] Available Session: `, ctx.session);
     if (!ctx.session) {

--- a/src/server/routers/user.ts
+++ b/src/server/routers/user.ts
@@ -3,7 +3,7 @@ import { Prisma, UserWorkout } from "@prisma/client";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import prisma from "@server/prisma/client";
-import { publicProcedure, router } from "@server/trpc";
+import { appUserProcedure, publicProcedure, router, sessionProcedure } from "@server/trpc";
 
 const defaultUserInclude = Prisma.validator<Prisma.UserInclude>()({
   workouts: false,
@@ -32,19 +32,19 @@ export const userRouter = router({
       })
     )
     .mutation(async ({ input: { username, password } }) => {
-      // throw new TRPCError({
-      //   code: "METHOD_NOT_SUPPORTED",
-      //   message: "not implemented ",
-      // });
-      const user = await prisma.user.findFirst({
-        where: {
-          name: username,
-        },
-        include: authorizedUserInclude,
+      throw new TRPCError({
+        code: "METHOD_NOT_SUPPORTED",
+        message: "not implemented ",
       });
-      return user;
+      // const user = await prisma.user.findFirst({
+      //   where: {
+      //     name: username,
+      //   },
+      //   include: authorizedUserInclude,
+      // });
+      // return user;
     }),
-  me_get_exercise_data_by_id: publicProcedure
+  my_specific_exercise_data: appUserProcedure
     .input(z.object({ exercise_id: z.string().uuid() }))
     .query(async ({ input: { exercise_id }, ctx }) => {
       const me = ctx.session!.user;
@@ -73,7 +73,7 @@ export const userRouter = router({
       console.log(ex_data);
       return ex_data;
     }),
-  get_by_name: publicProcedure
+  get_user_by_name: sessionProcedure
     .input(z.object({ name: z.string() }))
     .query(async ({ ctx, input: { name } }) => {
       const user = await prisma?.user.findFirst({

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -7,7 +7,7 @@
  * @link https://trpc.io/docs/v10/router
  * @link https://trpc.io/docs/v10/procedures
  */
-import { initTRPC } from '@trpc/server';
+import { initTRPC, TRPCError } from '@trpc/server';
 import superjson from 'superjson';
 import { TRPCClientCtx } from './context';
 const trpcClient = initTRPC.context<TRPCClientCtx>().create({
@@ -42,6 +42,26 @@ export const router = trpcClient.router;
  * @link https://trpc.io/docs/v10/procedures
  **/
 export const publicProcedure = trpcClient.procedure;
+
+// these procedures all validate the user with the action
+export const sessionProcedure = publicProcedure.use(async (opts) => {
+    if (!opts.ctx.session) {
+      throw new TRPCError({code: "UNAUTHORIZED", message: "NO_SESSION. No auth session found for incoming request."});
+    }
+    console.log("[trpc handler][Session Procedure]: incoming opts for procedure:", opts.path);
+    console.log("[trpc handler][Session Procedure]: request cookies: ", opts.ctx.req?.cookies);
+    console.log("[trpc handler][Session Procedure]: request headers: ", opts.ctx.req?.headers);
+    return opts.next(opts);
+  }
+);
+export const appUserProcedure = sessionProcedure.use(async (opts) => {
+  // ensure the cookie auth token matches up with the db auth token
+  if (!opts.ctx.session?.user.id) {
+    throw new TRPCError({code: "UNPROCESSABLE_CONTENT", message: "No user id found in session for current user."});
+  
+  }
+  return opts.next(opts);
+});
 /**
  * @link https://trpc.io/docs/v10/merging-routers
  */


### PR DESCRIPTION
- sessionProcedure will be used for queries that i want to requires a next auth session for.
- appUserProcedure (extends sessionProcedure) will be used for any __current__ user related private queries/mutations.