### PR TITLE
[hotfix]: Response header caching fixed for public routes

### DIFF
--- a/src/pages/api/trpc/[trpc].ts
+++ b/src/pages/api/trpc/[trpc].ts
@@ -39,18 +39,7 @@ export default createNextApiHandler({
     console.log("[trpc Handler] Response Object Exists: ", !!ctx?.res)
     console.log("[trpc Handler] Response Session: ", ctx?.session)
     console.log("[trpc Handler] Response Data: ", data)
-    const safe_to_cache = paths && paths.every(path => path.includes("public")) && errors.length === 0;
-    const ONE_HOUR_IN_SECONDS = 60 * 60;
-    const ONE_DAY_IN_SECONDS = ONE_HOUR_IN_SECONDS * 24;
-    const ONE_WEEK_IN_SECONDS = ONE_DAY_IN_SECONDS * 7;
-    if (safe_to_cache) {
-      console.log("[trpc Handler] Adding Cache headers to public query response: ", paths)
-      const headers = {
-        "cache-control": `s-maxage=${ONE_WEEK_IN_SECONDS}, public, stale-while-revalidate=${ONE_DAY_IN_SECONDS}`
-      };
-      console.log("[trpc Handler] Set Response Headers: ", headers)
-      return headers;
-    } else return {}
+    return {};
   },
   router: appRouter,
   /**

--- a/src/server/routers/exercise.ts
+++ b/src/server/routers/exercise.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import prisma from "@server/prisma/client";
 import { defaultWorkoutSelect, open_workout_if_exists } from "./workout";
 import { Exercise } from "@prisma/client";
-import { appUserProcedure, publicProcedure, router } from "@server/trpc";
+import { appUserProcedure, cachedProcedure, publicProcedure, router } from "@server/trpc";
 
 export const exerciseRouter = router({
   public_search_exercises: publicProcedure
@@ -83,7 +83,7 @@ export const exerciseRouter = router({
       console.log("order matches?: ", doesOrderMatch())
       return found_exercises;
     }),
-  public_directory: publicProcedure
+  public_directory: cachedProcedure
     .query(async() => { return await prisma.exercise.findMany() }),
   my_unique_recent: appUserProcedure
     .input( z.object({ limit: z.number().optional().default(25) }))


### PR DESCRIPTION
- moved from using the `reponseMeta` callback to setting the header in the a trpc procedure middleware
    - see `cachedProcedure`
    - use the responseMeta callback seems to be bugged. Headers would not be set properly.