### PR TITLE
[minor][ui]: Use `100dvh` for main app container `div` height

### DIFF
--- a/src/layouts/mainLayout.tsx
+++ b/src/layouts/mainLayout.tsx
@@ -66,7 +66,7 @@ export const MainLayout = ({ session, children, appLocation }: LayoutProps) => {
                 e.stopPropagation();
             }}
             className="flex
-                    h-screen
+                    h-[100dvh]
                     flex-col
                     overflow-hidden
                     /border-4


### PR DESCRIPTION
- this will make the apps height adjust to the viewport height when things like keyboards and search bars are opened on mobile.